### PR TITLE
Access postal code from autocomplete results

### DIFF
--- a/lib/gplaces/place.rb
+++ b/lib/gplaces/place.rb
@@ -17,12 +17,13 @@ module Gplaces
   end
 
   class Place
-    attr_reader :name, :location, :city
+    attr_reader :name, :location, :city, :postal_code
 
     def initialize(attributes)
-      @name     = attributes[:name]
-      @location = location_from(attributes[:geometry])
-      @city     = city_from_address_components(attributes[:address_components])
+      @name        = attributes[:name]
+      @location    = location_from(attributes[:geometry])
+      @city        = extract(:locality, attributes[:address_components])
+      @postal_code = extract(:postal_code, attributes[:address_components])
     end
 
     private
@@ -33,12 +34,12 @@ module Gplaces
       Location.new(geometry[:location])
     end
 
-    def city_from_address_components(components)
+    def extract(key, components)
       return if components.nil? || components.empty?
 
       components.each do |component|
         types = component[:types]
-        return component[:long_name] if types && types.include?("locality")
+        return component[:long_name] if types && types.include?(key.to_s)
       end
       nil
     end

--- a/spec/lib/gplaces/client_spec.rb
+++ b/spec/lib/gplaces/client_spec.rb
@@ -37,8 +37,12 @@ RSpec.describe Gplaces::Client do
         .to_return(fixture("details.json"))
     end
 
-    it "gets the place details" do
+    it "gets the place details (city)" do
       expect(client.details("ChIJl-emOTauEmsRVuhkf-gObv8", "en").city).to eq("Pyrmont")
+    end
+
+    it "gets the place details (postal code)" do
+      expect(client.details("ChIJl-emOTauEmsRVuhkf-gObv8", "en").postal_code).to eq("2009")
     end
 
     context "when place details are not available" do

--- a/spec/lib/gplaces/place_spec.rb
+++ b/spec/lib/gplaces/place_spec.rb
@@ -26,4 +26,18 @@ RSpec.describe Gplaces::Place do
 
     expect(place.city).to eq("Long Name")
   end
+
+  it "has a postal code" do
+    place = described_class.new(
+      address_components: [
+        {
+          long_name:  "555-123",
+          short_name: "555",
+          types:      %w(postal_code),
+        },
+      ]
+    )
+
+    expect(place.postal_code).to eq("555-123")
+  end
 end


### PR DESCRIPTION
- Accessor for `postal_code` field returned by Google Autocomplete API
- Refactor field extraction method in `Place` to be generic and support additional field retrieval.
